### PR TITLE
WIP : Remote monitor node implementation

### DIFF
--- a/ros_ws/src/monitor/CMakeLists.txt
+++ b/ros_ws/src/monitor/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(monitor)
+
+add_compile_options(-std=c++17)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+)
+
+
+###################################
+## catkin specific configuration ##
+###################################
+
+catkin_package(
+  INCLUDE_DIRS include
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(video_monitor
+  src/video_monitor.cpp
+)
+
+target_link_libraries(video_monitor
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_serial.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)
+

--- a/ros_ws/src/monitor/launch/monitor.launch
+++ b/ros_ws/src/monitor/launch/monitor.launch
@@ -1,0 +1,9 @@
+<launch>
+    <!-- Args -->
+
+    <!-- Nodes -->
+    <node name="monitor" pkg="monitor" type="video_monitor" output="screen">
+    </node>
+
+</launch>
+

--- a/ros_ws/src/monitor/package.xml
+++ b/ros_ws/src/monitor/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>monitor</name>
+  <version>0.1.0</version>
+  <description>Video and textual monitor nodes for the computer vision team</description>
+
+  <maintainer email="sebastien.darche@polymtl.ca">Sébastien Darche</maintainer>
+
+  <license>MIT</license>
+
+  <author email="sebastien.darche@polymtl.ca">Sébastien Darche</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <export></export>
+
+</package>
+

--- a/ros_ws/src/monitor/src/video_monitor.cpp
+++ b/ros_ws/src/monitor/src/video_monitor.cpp
@@ -1,0 +1,20 @@
+/** \file video_monitor.cpp
+ * \brief Video monitor node executable
+ *
+ * \author Sébastien Darche <sebastien.darche@polymtl.ca>
+ */
+
+// ROS includes
+
+#include <ros/ros.h>
+
+
+/** \brief This node shows the current video stream as well as the detected bounding boxes
+ */
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "video_monitor");
+    ros::NodeHandle nh;
+
+    ros::spin();
+}
+


### PR DESCRIPTION
These nodes should serve as our main interface with the computer vision system : 

- Print basic information on the message being exchanged in relevant topics (e.g. : target position)
- Display the camera stream and the detected bounding boxes

These nodes should be "hot-pluggable" : a remote computer can connect to the embedded computer and fetch the relevant pieces of information. This should be easy given ROS' network capabilities.